### PR TITLE
Remove escaping when parsing MARATHON_ARGS environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 targets
 tmp
 *.jar
+src/1.5.x/marathon
 artifacts
 *.dylib

--- a/src/1.4.x/lib/bindings.sc
+++ b/src/1.4.x/lib/bindings.sc
@@ -33,12 +33,7 @@ case class StorageToolModule(
   migration: Migration
 )
 
-object MarathonStorage {
-  def argsFromEnv: List[String] = {
-    "(?<!\\\\)( +)".r.split(sys.env.getOrElse("MARATHON_ARGS", "").trim).toList.filterNot(_ == "")
-  }
-}
-class MarathonStorage(args: List[String] = MarathonStorage.argsFromEnv) {
+class MarathonStorage(args: List[String] = helpers.InternalHelpers.argsFromEnv) {
   import helpers.Helpers._
   implicit val actorSystem = ActorSystem()
   implicit val actorMaterializer = ActorMaterializer()

--- a/src/1.5.x/lib/bindings.sc
+++ b/src/1.5.x/lib/bindings.sc
@@ -38,13 +38,7 @@ case class StorageToolModule(
   migration: Migration
 )
 
-object MarathonStorage {
-  def argsFromEnv: List[String] = {
-    "(?<!\\\\)( +)".r.split(sys.env.getOrElse("MARATHON_ARGS", "").trim).toList.filterNot(_ == "")
-  }
-}
-
-class MarathonStorage(args: List[String] = MarathonStorage.argsFromEnv) {
+class MarathonStorage(args: List[String] = helpers.InternalHelpers.argsFromEnv) {
   import helpers.Helpers._
   implicit val actorSystem = ActorSystem()
   implicit val actorMaterializer = ActorMaterializer()

--- a/src/1.5.x/lib/helpers.sc
+++ b/src/1.5.x/lib/helpers.sc
@@ -14,6 +14,11 @@ object InternalHelpers {
     "(?<!\\\\)( +)".r.split(sys.env.getOrElse("MARATHON_ARGS", "").trim)
       .filterNot(_ == "")
       .map { arg =>
+        /* This unescapes an argument by simply removing the leading backslashes
+         * 'zk://zk-1.zk\,zk-2.zk:8181/marathon'
+         *   becomes
+         * 'zk://zk-1.zk,zk-2.zk:8181/marathon'
+         */
         arg.replaceAll("\\\\(.)", "$1")
       }
       .toList

--- a/src/1.5.x/lib/helpers.sc
+++ b/src/1.5.x/lib/helpers.sc
@@ -11,7 +11,12 @@ object InternalHelpers {
     * does not take additional program arguments.
     */
   def argsFromEnv: List[String] = {
-    "(?<!\\\\)( +)".r.split(sys.env.getOrElse("MARATHON_ARGS", "").trim).toList.filterNot(_ == "")
+    "(?<!\\\\)( +)".r.split(sys.env.getOrElse("MARATHON_ARGS", "").trim)
+      .filterNot(_ == "")
+      .map { arg =>
+        arg.replaceAll("\\\\(.)", "$1")
+      }
+      .toList
   }
 }
 

--- a/src/1.5.x/marathon
+++ b/src/1.5.x/marathon
@@ -1,1 +1,0 @@
-../../../marathon-stable/target/universal/stage


### PR DESCRIPTION
Also, there were duplicate definitions of argsFromEnv. Remove them

Fixes #5