### PR TITLE
Call markOpen method for storage

### DIFF
--- a/src/1.4.x/lib/bindings.sc
+++ b/src/1.4.x/lib/bindings.sc
@@ -69,11 +69,20 @@ class MarathonStorage(args: List[String] = helpers.InternalHelpers.argsFromEnv) 
   implicit lazy val storage = StorageConfig(config) match {
     case zk: CuratorZk => zk
   }
+  lazy val store = {
+    val s = storage.store
+    // We need to call this method before using the storage module if it is defined
+    s.getClass.getMethods.find(_.getName == "markOpen").foreach { m =>
+      m.invoke(s)
+    }
+    s
+  }
+
   implicit lazy val client = storage.client
   implicit lazy val underlyingModule = StorageModule(storage, None)
   implicit lazy val module = StorageToolModule(
-    appRepository = AppRepository.zkRepository(storage.store),
-    podRepository = PodRepository.zkRepository(storage.store),
+    appRepository = AppRepository.zkRepository(store),
+    podRepository = PodRepository.zkRepository(store),
     instanceRepository = underlyingModule.instanceRepository,
     deploymentRepository = underlyingModule.deploymentRepository,
     taskFailureRepository = underlyingModule.taskFailureRepository,
@@ -84,7 +93,7 @@ class MarathonStorage(args: List[String] = helpers.InternalHelpers.argsFromEnv) 
 
   def assertStoreCompat: Unit = {
     def formattedVersion(v: StorageVersion): String = s"${v.getMajor}.${v.getMinor}.${v.getPatch}"
-    val storageVersion = await(storage.store.storageVersion()).getOrElse {
+    val storageVersion = await(store.storageVersion()).getOrElse {
       error(s"Could not determine current storage version!")
     }
     if ((storageVersion.getMajor == StorageVersions.current.getMajor) &&


### PR DESCRIPTION
Marathon-storage-tool failed to launch for versions of Marathon that
have this safety in place. Unfortunately, 1.4.9 onward and 1.5.2 onward
have this flag, but prior versions do not. In order to reduce the number
of different implementations for bindings, dynamic dispatch is used to
call the method only if it is defined.